### PR TITLE
Fix wrong property name for "dir" command result

### DIFF
--- a/nsapi/Dir-NetstorageDirectory.ps1
+++ b/nsapi/Dir-NetstorageDirectory.ps1
@@ -28,7 +28,7 @@ function Dir-NetstorageDirectory {
 
     try {
         $Result = Invoke-AkamaiNSAPIRequest -Path $Path -Action $Action -AdditionalOptions $AdditionalOptions -AuthFile $Authfile -Section $Section
-        return $Result.list.file
+        return $Result.stat.file
     }
     catch {
         throw $_


### PR DESCRIPTION
Use the correct property name when returning the results of the "dir" command